### PR TITLE
Make ProjectileBouncingHelper use Projectile2D `collision_shape` and `transform`

### DIFF
--- a/addons/godot_projectile_engine/core/projectile_environment/projectile_environment.gd
+++ b/addons/godot_projectile_engine/core/projectile_environment/projectile_environment.gd
@@ -41,12 +41,11 @@ func get_projectile_damage(projectile_area_rid: RID) -> int:
 	return 0
 
 
-func request_bouncing_helper(asdfasdfas: CollisionShape2D) -> void:
+func request_bouncing_helper(_projectile_collision_shape: CollisionShape2D) -> void:
 	if projectile_bouncing_helper: return
 	projectile_bouncing_helper = ProjectileBouncingHelper.new()
 	var _collision_shape := CollisionShape2D.new()
-	var _shape : = CircleShape2D.new()
-	_shape.radius = 6.0
+	var _shape : = _projectile_collision_shape.shape
 	_collision_shape.shape = _shape
 
 	# var 

--- a/addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/bouncing/projectile_component_bouncing.gd
+++ b/addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/bouncing/projectile_component_bouncing.gd
@@ -40,6 +40,8 @@ func _physics_process(delta: float) -> void:
 
 	if !_collision_body:
 		ProjectileEngine.projectile_environment.request_bouncing_helper(_projectile_2d.get_node("CollisionShape2D").duplicate())
+		ProjectileEngine.projectile_environment.projectile_bouncing_helper.transform = _projectile_2d.transform
+		# ProjectileEngine.projectile_environment.projectile_bouncing_helper.force_update_transform()
 		_collision_body = ProjectileEngine.projectile_environment.projectile_bouncing_helper
 	
 	if !component_behaviors:
@@ -76,7 +78,8 @@ func _on_body_entered(body: Node2D) -> void:
 	if max_bounces >= 0 and bounce_count >= max_bounces:
 		max_bounces_reached.emit(bounce_count)
 		return
-
+	_collision_body.transform = _projectile_2d.transform
+	_collision_body.force_update_transform()
 	_collision_body.collision_layer = _projectile_2d.collision_layer
 	_collision_body.collision_mask = _projectile_2d.collision_mask
 	_collision_body.global_position = _projectile_2d.global_position

--- a/addons/godot_projectile_engine/examples/asset/projectile_template/projectile_template_node_2d/projectile_2d_test_2.tscn
+++ b/addons/godot_projectile_engine/examples/asset/projectile_template/projectile_template_node_2d/projectile_2d_test_2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=3 uid="uid://8uyn7n15umu0"]
+[gd_scene load_steps=30 format=3 uid="uid://8uyn7n15umu0"]
 
 [ext_resource type="Script" uid="uid://d1jrqiont4u2h" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/entities/projectile_2d.gd" id="1_3ihmi"]
 [ext_resource type="Texture2D" uid="uid://daxkxvl7s1nr3" path="res://addons/godot_projectile_engine/examples/asset/projectile/projectile_rice_1.png" id="2_re2lw"]
@@ -9,21 +9,23 @@
 [ext_resource type="Script" uid="uid://dipo0d1s8vqo" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/direction/projectile_component_direction.gd" id="6_hfyjc"]
 [ext_resource type="Script" uid="uid://egh01yr3fqho" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/scale/projectile_component_scale.gd" id="7_78psp"]
 [ext_resource type="Script" uid="uid://chmjku6lmvmaq" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/speed/behaviors/projectile_speed_clamp.gd" id="7_224pb"]
-[ext_resource type="Script" uid="uid://chtssqssdvls7" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/base/projectile_behavior_direction.gd" id="7_k7cqt"]
 [ext_resource type="Script" uid="uid://bdk51xt0hiwtb" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/rotation/projectile_component_rotation.gd" id="8_pf7mb"]
-[ext_resource type="Curve2D" uid="uid://bt8dtk3k0xac0" path="res://experiments/experiment_projectile_template/square_curve_2d.tres" id="8_rk0ap"]
-[ext_resource type="Script" uid="uid://cjtoo7n0xa5e2" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/direction/behaviors/projectile_direction_curve_2d.gd" id="9_jfmow"]
 [ext_resource type="Script" uid="uid://lr7r36tmtarr" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/base/projectile_behavior_rotation.gd" id="9_nv04k"]
-[ext_resource type="Script" uid="uid://bpntc8lt06yr8" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/rotation/behaviors/projectile_rotation_follow_direction.gd" id="10_d1v0a"]
+[ext_resource type="Script" uid="uid://dqtdroky03dsm" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/base/projectile_behavior_scale.gd" id="10_3ihmi"]
 [ext_resource type="Script" uid="uid://d25cx5bje24ld" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/skew/projectile_component_skew.gd" id="11_qff6y"]
+[ext_resource type="Script" uid="uid://d0yojlb4mvhsj" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/scale/behaviors/projectile_scale_accelerate.gd" id="11_re2lw"]
 [ext_resource type="Script" uid="uid://b5mbns78winfj" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/life_time/projectile_component_life_time.gd" id="12_jvy66"]
 [ext_resource type="Script" uid="uid://cgkooc2hci3xy" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/life_distance/projectile_component_life_distance.gd" id="13_r7sfx"]
+[ext_resource type="Script" uid="uid://btri3e8whkvjv" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/rotation/behaviors/projectile_rotation_spin.gd" id="14_3ihmi"]
 [ext_resource type="Script" uid="uid://c5xm8oap2qr4y" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/destroy/behaviors/projectile_destroy_time.gd" id="15_f4kme"]
 [ext_resource type="Script" uid="uid://chg5nxeot0crs" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/destroy/projectile_component_destroy.gd" id="18_edgrl"]
+[ext_resource type="Script" uid="uid://yhl0aii1go5n" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/bouncing/projectile_component_bouncing.gd" id="19_f0i5g"]
 [ext_resource type="Script" uid="uid://b8xk7m2n5qr3w" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/base/projectile_behavior_destroy.gd" id="19_u6tcg"]
+[ext_resource type="Script" uid="uid://dg832mp2dyxuh" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/base/projectile_behavior_bouncing.gd" id="20_224pb"]
+[ext_resource type="Script" uid="uid://jrux0ns07ryt" path="res://addons/godot_projectile_engine/core/projectile_template/projectile_template_node_2d/components/bouncing/behaviors/projectile_bounce_ricochet.gd" id="21_3ihmi"]
 
-[sub_resource type="CircleShape2D" id="CircleShape2D_84ii0"]
-radius = 5.0
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_3ihmi"]
+size = Vector2(16, 8)
 
 [sub_resource type="Resource" id="Resource_3ihmi"]
 script = ExtResource("7_224pb")
@@ -32,19 +34,20 @@ min_value = -300.0
 active = true
 metadata/_custom_type_script = "uid://chmjku6lmvmaq"
 
-[sub_resource type="Resource" id="Resource_f0i5g"]
-script = ExtResource("9_jfmow")
-curve_2d = ExtResource("8_rk0ap")
-curve_strenght = 0.5
-direction_curve_sample_method = 1
-direction_modify_method = 0
+[sub_resource type="Resource" id="Resource_cixw6"]
+script = ExtResource("11_re2lw")
+acceleration_speed = 1.0
+max_scale = 3.0
 active = true
-metadata/_custom_type_script = "uid://cjtoo7n0xa5e2"
+metadata/_custom_type_script = "uid://d0yojlb4mvhsj"
 
-[sub_resource type="Resource" id="Resource_y7es0"]
-script = ExtResource("10_d1v0a")
+[sub_resource type="Resource" id="Resource_5ewh1"]
+script = ExtResource("14_3ihmi")
+spin_speed = 1.07338
+process_mode = 0
+modify_method = 0
 active = true
-metadata/_custom_type_script = "uid://bpntc8lt06yr8"
+metadata/_custom_type_script = "uid://btri3e8whkvjv"
 
 [sub_resource type="Resource" id="Resource_wy1ms"]
 script = ExtResource("15_f4kme")
@@ -53,6 +56,11 @@ emit_destroy_signal = true
 active = true
 metadata/_custom_type_script = "uid://c5xm8oap2qr4y"
 
+[sub_resource type="Resource" id="Resource_re2lw"]
+script = ExtResource("21_3ihmi")
+active = true
+metadata/_custom_type_script = "uid://jrux0ns07ryt"
+
 [node name="Projectile2dTest1" type="Area2D"]
 collision_layer = 32
 collision_mask = 256
@@ -60,7 +68,7 @@ script = ExtResource("1_3ihmi")
 metadata/_custom_type_script = "uid://d1jrqiont4u2h"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("CircleShape2D_84ii0")
+shape = SubResource("RectangleShape2D_3ihmi")
 
 [node name="ProjectileBigCirle1" type="Sprite2D" parent="."]
 texture_filter = 1
@@ -88,14 +96,14 @@ metadata/_custom_type_script = "uid://cnsqe5loyr8wg"
 
 [node name="ProjectileComponentDirection" type="Node" parent="ProjectileComponent/ProjectileComponentTransform2D/ProjectileComponentPosition"]
 script = ExtResource("6_hfyjc")
-component_behaviors = Array[ExtResource("7_k7cqt")]([SubResource("Resource_f0i5g")])
 
 [node name="ProjectileComponentScale" type="Node" parent="ProjectileComponent/ProjectileComponentTransform2D"]
 script = ExtResource("7_78psp")
+component_behaviors = Array[ExtResource("10_3ihmi")]([SubResource("Resource_cixw6")])
 
 [node name="ProjectileComponentRotation" type="Node" parent="ProjectileComponent/ProjectileComponentTransform2D"]
 script = ExtResource("8_pf7mb")
-component_behaviors = Array[ExtResource("9_nv04k")]([SubResource("Resource_y7es0")])
+component_behaviors = Array[ExtResource("9_nv04k")]([SubResource("Resource_5ewh1")])
 
 [node name="ProjectileComponentSkew" type="Node" parent="ProjectileComponent/ProjectileComponentTransform2D"]
 script = ExtResource("11_qff6y")
@@ -109,7 +117,12 @@ script = ExtResource("18_edgrl")
 component_behaviors = Array[ExtResource("19_u6tcg")]([SubResource("Resource_wy1ms")])
 metadata/_custom_type_script = "uid://chg5nxeot0crs"
 
-[node name="ProjectileComponentLifeDistance" type="Node" parent="." node_paths=PackedStringArray("projectile_transform_2d")]
+[node name="ProjectileComponentBouncing" type="Node" parent="ProjectileComponent"]
+script = ExtResource("19_f0i5g")
+component_behaviors = Array[ExtResource("20_224pb")]([SubResource("Resource_re2lw")])
+metadata/_custom_type_script = "uid://yhl0aii1go5n"
+
+[node name="ProjectileComponentLifeDistance" type="Node" parent="ProjectileComponent" node_paths=PackedStringArray("projectile_transform_2d")]
 script = ExtResource("13_r7sfx")
-projectile_transform_2d = NodePath("../ProjectileComponent/ProjectileComponentTransform2D")
+projectile_transform_2d = NodePath("../ProjectileComponentTransform2D")
 metadata/_custom_type_script = "uid://cgkooc2hci3xy"

--- a/experiments/experiment_projectile_template/experiment_pattern_composer_2.tscn
+++ b/experiments/experiment_projectile_template/experiment_pattern_composer_2.tscn
@@ -1,14 +1,17 @@
-[gd_scene load_steps=10 format=3 uid="uid://cpblpu3hsp6et"]
+[gd_scene load_steps=11 format=3 uid="uid://cpblpu3hsp6et"]
 
 [ext_resource type="Script" uid="uid://dn7rm61wq3t3s" path="res://addons/godot_projectile_engine/core/projectile_environment/projectile_environment.gd" id="1_gur78"]
 [ext_resource type="Script" uid="uid://cnqgcej10tinn" path="res://addons/godot_projectile_engine/core/projectile_spawner/projectile_spawner.gd" id="2_aydl5"]
-[ext_resource type="Resource" uid="uid://ly3vsgsyh7lu" path="res://experiments/experiment_projectile_template/projectile_template_custom_1.tres" id="3_5epyj"]
+[ext_resource type="Resource" uid="uid://dwpqrf585p5k2" path="res://experiments/experiment_projectile_template/projectile_template_node_1.tres" id="3_5epyj"]
 [ext_resource type="Script" uid="uid://co24jiat0y46s" path="res://addons/godot_projectile_engine/core/pattern_composer/projectile_pattern_composer/PCCSingle2D.gd" id="6_5epyj"]
 [ext_resource type="Script" uid="uid://cm1gi15tdc45s" path="res://addons/godot_projectile_engine/core/pattern_composer/projectile_pattern_composer/PCCPolygon2D.gd" id="7_5epyj"]
 [ext_resource type="Script" uid="uid://b8nclaklcf4uu" path="res://addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler.gd" id="7_ir6nx"]
 [ext_resource type="Script" uid="uid://sjpvs4m6jk71" path="res://addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_repeater.gd" id="8_ta78m"]
 [ext_resource type="Script" uid="uid://brqy6ew0t2b35" path="res://addons/godot_projectile_engine/core/pattern_composer/projectile_pattern_composer/PCCSpread2D.gd" id="9_gur78"]
 [ext_resource type="Script" uid="uid://bc73oiea731jc" path="res://addons/godot_projectile_engine/core/pattern_composer/pattern_composer.gd" id="9_trsjv"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_5epyj"]
+size = Vector2(20, 131)
 
 [node name="ExperimentPatternComposer2" type="Node2D"]
 
@@ -37,10 +40,12 @@ metadata/_custom_type_script = "uid://co24jiat0y46s"
 script = ExtResource("7_5epyj")
 polygon_sides = 10
 spread_out = true
+active = false
 metadata/_custom_type_script = "uid://cm1gi15tdc45s"
 
 [node name="PCCSpread2D" type="Node" parent="PatternComposer2D"]
 script = ExtResource("9_gur78")
+active = false
 metadata/_custom_type_script = "uid://brqy6ew0t2b35"
 
 [node name="TimingScheduler" type="Node" parent="."]
@@ -60,3 +65,13 @@ position = Vector2(113, -98)
 
 [node name="HomingTarget2" type="Node2D" parent="." groups=["TestHoming"]]
 position = Vector2(113, 56)
+
+[node name="BoucningTarget" type="StaticBody2D" parent="."]
+position = Vector2(227, -2)
+collision_layer = 288
+collision_mask = 288
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="BoucningTarget"]
+position = Vector2(15, 9)
+rotation = 0.263645
+shape = SubResource("RectangleShape2D_5epyj")


### PR DESCRIPTION
- Rename `asdfasdfas` parameter to `_projectile_collision_shape` for clarity in `projectile_environment.gd`
- Reuse projectile's collision shape for bouncing helper instead of hardcoded circle
- Update bouncing helper's transform to match projectile during collisions
- Add transform synchronization when requesting bouncing helper