### PR TITLE
Fix Timing Scheulder cant restart when `repeat_count < 0` when use `StopMethod.SOFT_STOP`

### DIFF
--- a/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler.gd
+++ b/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler.gd
@@ -102,6 +102,7 @@ func _start_timing_scheduler() -> void:
 
 
 func _hard_stop_timing_scheduler() -> void:
+	print(current_tsc)
 	if not current_tsc:
 		return
 		
@@ -118,6 +119,7 @@ func _soft_stop_timing_scheduler() -> void:
 		return
 		
 	_disconnect_tsc_signals(current_tsc)
+	current_tsc.request_stop = true
 	if !current_tsc.tsc_completed.is_connected(_on_soft_stop_tsc_completed):
 		current_tsc.tsc_completed.connect(_on_soft_stop_tsc_completed)
 
@@ -182,6 +184,7 @@ func _on_tsc_completed() -> void:
 
 ## Handles completion during soft stop
 func _on_soft_stop_tsc_completed() -> void:
+	current_tsc.stop_tsc()
 	paused = true
 	current_tsc.tsc_completed.disconnect(_on_soft_stop_tsc_completed)
 	current_tsc = null

--- a/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/timing_scheduler_component.gd
+++ b/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/timing_scheduler_component.gd
@@ -20,6 +20,7 @@ enum UpdateMode {
 
 var timing_timer: Timer
 
+var request_stop : bool = false
 
 func start_next_timing_value() -> void:
 	pass

--- a/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_repeater.gd
+++ b/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_repeater.gd
@@ -31,9 +31,14 @@ func start_next_timing_value() -> void:
 ## Handles timer timeout events
 func on_timing_timer_timeout() -> void:
 	if repeat_count < 0:
-		# Infinite mode - always restart timer
-		tsc_timed.emit()
-		timing_timer.start(duration)
+		# For Soft Stop
+		if request_stop:
+			tsc_completed.emit()
+			request_stop = false
+		else:
+			# Infinite mode - always restart timer
+			tsc_timed.emit()
+			timing_timer.start(duration)
 	else:
 		# Finite mode - increment count and check if complete
 		current_count += 1
@@ -42,3 +47,4 @@ func on_timing_timer_timeout() -> void:
 			timing_timer.start(duration)
 		else:
 			tsc_completed.emit()
+		

--- a/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_timing_set/tsc_timing_set.gd
+++ b/addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_timing_set/tsc_timing_set.gd
@@ -49,6 +49,10 @@ func start_next_timing_value() -> void:
 		tsc_completed.emit()
 		stop_tsc()
 		return
+	if timing_set.repeat_count < 0:
+		if request_stop:
+			tsc_completed.emit()
+			request_stop = false
 
 	_current_interval = get_next_timing_value()
 

--- a/experiments/experiment_projectile_template/experiment_pattern_composer_2.tscn
+++ b/experiments/experiment_projectile_template/experiment_pattern_composer_2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://cpblpu3hsp6et"]
+[gd_scene load_steps=13 format=3 uid="uid://cpblpu3hsp6et"]
 
 [ext_resource type="Script" uid="uid://dn7rm61wq3t3s" path="res://addons/godot_projectile_engine/core/projectile_environment/projectile_environment.gd" id="1_gur78"]
 [ext_resource type="Script" uid="uid://cnqgcej10tinn" path="res://addons/godot_projectile_engine/core/projectile_spawner/projectile_spawner.gd" id="2_aydl5"]
@@ -6,9 +6,17 @@
 [ext_resource type="Script" uid="uid://co24jiat0y46s" path="res://addons/godot_projectile_engine/core/pattern_composer/projectile_pattern_composer/PCCSingle2D.gd" id="6_5epyj"]
 [ext_resource type="Script" uid="uid://cm1gi15tdc45s" path="res://addons/godot_projectile_engine/core/pattern_composer/projectile_pattern_composer/PCCPolygon2D.gd" id="7_5epyj"]
 [ext_resource type="Script" uid="uid://b8nclaklcf4uu" path="res://addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler.gd" id="7_ir6nx"]
-[ext_resource type="Script" uid="uid://sjpvs4m6jk71" path="res://addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_repeater.gd" id="8_ta78m"]
+[ext_resource type="Script" uid="uid://cwr176dncae0f" path="res://addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_timing_set/tsc_timing_set.gd" id="9_5epyj"]
 [ext_resource type="Script" uid="uid://brqy6ew0t2b35" path="res://addons/godot_projectile_engine/core/pattern_composer/projectile_pattern_composer/PCCSpread2D.gd" id="9_gur78"]
 [ext_resource type="Script" uid="uid://bc73oiea731jc" path="res://addons/godot_projectile_engine/core/pattern_composer/pattern_composer.gd" id="9_trsjv"]
+[ext_resource type="Script" uid="uid://ssup2p0b2bqp" path="res://addons/godot_projectile_engine/core/timing_scheduler/timing_scheduler_component/tsc_timing_set/timing_set.gd" id="10_h8t1e"]
+
+[sub_resource type="Resource" id="Resource_gur78"]
+script = ExtResource("10_h8t1e")
+entries = Array[float]([0.2])
+playback_mode = 0
+repeat_count = -1
+metadata/_custom_type_script = "uid://ssup2p0b2bqp"
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5epyj"]
 size = Vector2(20, 131)
@@ -52,11 +60,10 @@ metadata/_custom_type_script = "uid://brqy6ew0t2b35"
 script = ExtResource("7_ir6nx")
 metadata/_custom_type_script = "uid://b8nclaklcf4uu"
 
-[node name="TSCRepeater" type="Node" parent="TimingScheduler"]
-script = ExtResource("8_ta78m")
-duration = 0.2
-repeat_count = 10
-metadata/_custom_type_script = "uid://sjpvs4m6jk71"
+[node name="TSCTimingSet" type="Node" parent="TimingScheduler"]
+script = ExtResource("9_5epyj")
+timing_set = SubResource("Resource_gur78")
+metadata/_custom_type_script = "uid://cwr176dncae0f"
 
 [node name="Camera2D" type="Camera2D" parent="."]
 

--- a/experiments/experiment_projectile_template/experiment_pattern_composer_2.tscn
+++ b/experiments/experiment_projectile_template/experiment_pattern_composer_2.tscn
@@ -30,6 +30,7 @@ metadata/_custom_type_script = "uid://dn7rm61wq3t3s"
 [node name="ProjectileSpawner2D" type="Node2D" parent="." node_paths=PackedStringArray("timing_scheduler")]
 position = Vector2(-3, 0)
 script = ExtResource("2_aydl5")
+active = false
 projectile_composer_name = "pattern_1"
 projectile_template_2d = ExtResource("3_5epyj")
 timing_scheduler = NodePath("../TimingScheduler")


### PR DESCRIPTION
- Add `request_stop` flag to timing components
- Modify repeater and timing set components to respect soft stop requests